### PR TITLE
Fix: Gunicorn sürümünü güvenlik açıklarını gidermek için 23.0.0'a gün…

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ python-dotenv==1.0.0
 pdfplumber==0.10.1
 requests==2.31.0
 Werkzeug==3.0.6
-gunicorn==21.2.0
+gunicorn==23.0.0
 lmstudio==0.0.1
 pyyaml
 fastapi


### PR DESCRIPTION
…celle

- Gunicorn sürümü 21.2.0'dan 23.0.0'a güncellendi

- HTTP Request/Response Smuggling (GH-#12) ve Endpoint kısıtlama atlatma (GH-#2) güvenlik açıkları giderildi

- CVE-2024-6827 ve CVE-2024-1135 çözüldü